### PR TITLE
fix api-docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from pathlib import Path
 import os
 import sys
 
@@ -16,6 +17,7 @@ author = "pyaerocom developers"
 # -- Add paths ---------------------------------------
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, str(Path("..", "src").resolve()))
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-from pathlib import Path
 import os
 import sys
 
@@ -17,7 +16,7 @@ author = "pyaerocom developers"
 # -- Add paths ---------------------------------------
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
-sys.path.insert(0, str(Path("..", "src").resolve()))
+# sys.path.insert(0, str(Path("..", "src").resolve())) # src not needed since pyaro is installed
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ sphinx_rtd_theme
 sphinx-argparse
 nbsphinx
 pandas
-pyaro @ git+https://github.com/metno/pyaro@main
+# pyaro @ git+https://github.com/metno/pyaro@main

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,8 @@ sphinxcontrib-napoleon
 sphinx_rtd_theme
 sphinx-argparse
 nbsphinx
+cf-units
+xarray
+netcdf4
 pandas
-# pyaro @ git+https://github.com/metno/pyaro@main
+pyaro @ git+https://github.com/metno/pyaro@main


### PR DESCRIPTION
Docs on https://pyaro.readthedocs.io/latest/api.html did no longer contain any api-documentation.
https://pyaro--52.org.readthedocs.build/52/api.html does fix this by providing the new optional packages as required packages for read-the-docs builds.

Read The Docs builds are now enabled for all PRs.

closes #51