### PR TITLE
54 cf units is a required dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,8 @@ sphinxcontrib-napoleon
 sphinx_rtd_theme
 sphinx-argparse
 nbsphinx
+cf-units
+xarray
+netcdf4
 pandas
 pyaro @ git+https://github.com/metno/pyaro@main

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,8 +4,5 @@ sphinxcontrib-napoleon
 sphinx_rtd_theme
 sphinx-argparse
 nbsphinx
-cf-units
-xarray
-netcdf4
 pandas
 pyaro @ git+https://github.com/metno/pyaro@main


### PR DESCRIPTION
Initialize all constants and data needed for RelativeAltitudeFilter lazy, since the init function is called when registering the filter.
Close netcdf-files/xr.Datasets with context-manager.
Avoid unnecessary object-variables.

Fixes #54 