### PR TITLE
AutoFilterEngine implementing open

### DIFF
--- a/docs/how-to-add-new-reader.rst
+++ b/docs/how-to-add-new-reader.rst
@@ -32,8 +32,8 @@ Subclassing of Engine/Reader using AutoFilterReaderEngine
 Your ``YourEngine`` should extend :py:class:`~pyaro.timeseries.AutoFilterReaderEngine.AutoFilterEngine`
 and it must implement the following methods:
 
-- :py:meth:`~pyaro.timeseries.AutoFilterReader.reader_class`: a class implementing `AutoFilterReader`,
-  typically `def reader_class(self) -> AutoFilterReader: return YourReader`
+- :py:meth:`~pyaro.timeseries.AutoFilterReaderEngine.reader_class`: the class implementing `AutoFilterReader`,
+  corresponding to this `AutoFilterReaderEngine`, i.e. `def reader_class(self) -> AutoFilterReader: return YourReader`
 - :py:meth:`~pyaro.timeseries.Engine.description`: a one-line description of this engine
 - :py:meth:`~pyaro.timeseries.Engine.url`: the link to the implementation source
 

--- a/docs/how-to-add-new-reader.rst
+++ b/docs/how-to-add-new-reader.rst
@@ -32,8 +32,8 @@ Subclassing of Engine/Reader using AutoFilterReaderEngine
 Your ``YourEngine`` should extend :py:class:`~pyaro.timeseries.AutoFilterReaderEngine.AutoFilterEngine`
 and it must implement the following methods:
 
-- :py:meth:`~pyaro.timeseries.Engine.open`: opening a reader with the signature (self, filename, *args, **kwargs) -> YourReader``,
-  usually just like: ``return YourReader(filename, *args, **kwargs)``
+- :py:meth:`~pyaro.timeseries.AutoFilterReader.reader_class`: a class implementing `AutoFilterReader`,
+  typically `def reader_class(self) -> AutoFilterReader: return YourReader`
 - :py:meth:`~pyaro.timeseries.Engine.description`: a one-line description of this engine
 - :py:meth:`~pyaro.timeseries.Engine.url`: the link to the implementation source
 
@@ -48,7 +48,7 @@ The ``YourReader`` should extend :py:class:`~pyaro.timeseries.AutoFilterReaderEn
 - the :py:meth:`~pyaro.timeseries.AutoFilterReaderEngine.AutoFilterReader._unfiltered_variables` method
 - the :py:meth:`~pyaro.timeseries.AutoFilterReaderEngine.AutoFilterReader.close` method (might be pass, but Readers are also contextmanagers and will call `close()`)
 
-A quite basic example of an implementation can be found in the :py:class:`~pyaro.csvreader.CSVTimeseriesReader`.
+An example of an implementation can be found in the :py:class:`~pyaro.csvreader.CSVTimeseriesReader`.
 
 Direct subclassing of Engine/Reader
 ###################################
@@ -85,7 +85,7 @@ This is what a ``TimeseriesReader`` subclass should look like:
             self,
             filename_or_obj_or_url,
             *,
-            filters=None,
+            filters=[],
             # other backend specific keyword arguments
             # `chunks` and `cache` DO NOT go here, they are handled by xarray
         ):
@@ -145,7 +145,7 @@ The input of ``open`` method are one argument
 
 - ``filename_or_obj_or_url``: can be any object but usually it is a string containing a path or an instance of
   :py:class:`pathlib.Path` or an url.
-- ``filters``: can be `None` or an iterable containing filters to be (optionally) applied when reading the data.
+- ``filters``: is an iterable containing filters to be (optionally) applied when reading the data.
 
 
 Your reader can also take as input a set of backend-specific keyword

--- a/src/pyaro/csvreader/CSVTimeseriesReader.py
+++ b/src/pyaro/csvreader/CSVTimeseriesReader.py
@@ -200,9 +200,6 @@ class CSVTimeseriesEngine(pyaro.timeseries.AutoFilterReaderEngine.AutoFilterEngi
     def reader_class(self):
         return CSVTimeseriesReader
 
-    def open(self, filename, *args, **kwargs) -> CSVTimeseriesReader:
-        return self.reader_class()(filename, *args, **kwargs)
-
     def description(self):
         return "Simple reader of csv-files using python csv-reader"
 

--- a/src/pyaro/timeseries/AutoFilterReaderEngine.py
+++ b/src/pyaro/timeseries/AutoFilterReaderEngine.py
@@ -123,3 +123,6 @@ class AutoFilterEngine(Engine):
         sig = inspect.signature(self.reader_class().__init__)
         pars = tuple(sig.parameters.keys())
         return pars[1:]
+
+    def open(self, filename, *args, **kwargs) -> Reader:
+        return self.reader_class()(filename, *args, **kwargs)


### PR DESCRIPTION
The `AutoFilterEngine` should for parity implement `open` as `args()` inspects `__init__` of `reader_class`