### PR TITLE
fix: Fix 0 elevation bug in relalt filter

### DIFF
--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1322,7 +1322,7 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
         within_radius = distances <= radius
 
         values_within_radius = topo[self._topo_var].where(
-            within_radius, other=False, drop=True
+            within_radius, other=np.nan, drop=True
         )
 
         min_value = float(values_within_radius.min(skipna=True))

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1315,8 +1315,16 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
         # At most one degree of latitude (at equator) is roughly 111km.
         # Subsetting to based on this value with safety margin makes the
         # distance calculation MUCH more efficient.
-        s = 0.1 + (radius / 1000) / 100
-        topo = topo.sel(lon=slice(lon - s, lon + s), lat=slice(lat - s, lat + s))
+        if radius < 100_000:
+            margin = 0.1 + (radius / 1_000) / 100
+            if lat >= 88 or lat <= -88:
+                # Include 360deg longitude near poles because poles are weird.
+                topo = topo.sel(lat=slice(lat - margin, lat + margin))
+            else:
+                topo = topo.sel(
+                    lon=slice(lon - margin, lon + margin),
+                    lat=slice(lat - margin, lat + margin),
+                )
 
         distances = haversine(topo["lon"], topo["lat"], lon, lat)
         within_radius = distances <= radius

--- a/tests/test_CSVTimeSeriesReader.py
+++ b/tests/test_CSVTimeSeriesReader.py
@@ -697,7 +697,7 @@ class TestCSVTimeSeriesReader(unittest.TestCase):
                 "flag": "0",
             },
         ) as ts:
-            self.assertEqual(len(ts.stations()), 1)
+            self.assertEqual(len(ts.stations()), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There was an issue where when filtering the elevation based on distance, the replacement value for excluded cells in the grid would be set to `False` which Python helpfully treats as `0` when determining the minimum altitude in the radius. As a consequence all sites would be compared to a valley floor of `0m`. Now the replacement is set properly to `NaN`, which should fix the valley floor calculation.

Thanks @heikoklein for finding the problem.