### PR TITLE
Allow directory in valleyfloor filter

### DIFF
--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1331,7 +1331,10 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
 
         filtered_stations = {}
 
-        for k, v in stations.items():
+        # Sorting stations by latitude minimizes reloading of data if each topo file
+        # is a band that includes 360deg of longitude. This is the case for the merged
+        # dataset.
+        for k, v in sorted(stations.items(), key=lambda x: x[1].latitude):
             lat = v.latitude
             lon = v.longitude
             alt = v.altitude

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1254,7 +1254,7 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
             )
 
         if not self._topo.exists():
-            raise FileNotFoundError(
+            logger.warning(
                 f"Provided location for topography data ({self._topo}) does not exist. It should be either a .nc file, or a folder with several .nc files and a metadata.json file."
             )
 

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1304,12 +1304,14 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
                 if lon < metadata[file]["w"] or lon > metadata[file]["e"]:
                     continue
 
+                self._topo_file = self._topo / file
+                break
+
             if file is None:
                 raise Exception(
                     f"No matching topography file found for coordinate pair (lat={lat:.6f}; lon={lon:.6f})"
                 )
 
-            self._topo_file = self._topo / file
         else:
             raise FileNotFoundError
 

--- a/tests/test_CSVTimeSeriesReader.py
+++ b/tests/test_CSVTimeSeriesReader.py
@@ -676,7 +676,7 @@ class TestCSVTimeSeriesReader(unittest.TestCase):
             filters=[
                 pyaro.timeseries.filters.get(
                     "valleyfloor_relaltitude",
-                    topo_file="tests/testdata/datadir_elevation/gtopo30_subset.nc",
+                    topo="tests/testdata/datadir_elevation/gtopo30_subset.nc",
                     radius=5000,
                     lower=150,
                     upper=250,


### PR DESCRIPTION
Adds possibility to specify a directory with multiple nc files to the valley floor filter. Needed to be able to use the filter globally without very high memory usage.

Currently this uses a `metadata.json` file which specifies the latitude/longitude bounds of each indiviudal file.

