### PR TITLE
Remove mandatory argument for Reader/Engine

### DIFF
--- a/docs/how-to-add-new-reader.rst
+++ b/docs/how-to-add-new-reader.rst
@@ -40,7 +40,7 @@ and it must implement the following methods:
 
 The ``YourReader`` should extend :py:class:`~pyaro.timeseries.AutoFilterReaderEngine.AutoFilterReader`
 
-- the ``__init__`` method of :py:class:`~pyaro.timeseries.Reader` with two fixed args (`self` and `filename_or_obj_or_url`) and several kwargs,
+- the ``__init__`` method of :py:class:`~pyaro.timeseries.Reader` with one fixed arg (`self`) and several kwargs,
   one of them should be `filters`
     - it must store the `filters` calling `self._set_filters(filters)`
 - the :py:meth:`~pyaro.timeseries.AutoFilterReaderEngine.AutoFilterReader._unfiltered_data` method
@@ -83,7 +83,7 @@ This is what a ``TimeseriesReader`` subclass should look like:
     class MyTimeseriesReader(Reader):
         def __init__(
             self,
-            filename_or_obj_or_url,
+            filename,
             *,
             filters=[],
             # other backend specific keyword arguments
@@ -102,11 +102,11 @@ This is what a ``TimeseriesReader`` subclass should look like:
             ...
 
     class MyTimeseriesEngine(Engine)
-        def open(self, filename_or_obj_or_url, *args, **kwargs):
-            return MyTimeseriesReader(filename_or_obj_or_url, *args, **kwargs)
+        def open(self, *args, **kwargs):
+            return MyTimeseriesReader(*args, **kwargs)
 
         def args(self):
-            open_parameters = ["filename_or_obj", "filters"]
+            open_parameters = ["filename", "filters"]
             return open_parameters
 
         def supported_filters(self):

--- a/src/pyaro/csvreader/CSVTimeseriesReader.py
+++ b/src/pyaro/csvreader/CSVTimeseriesReader.py
@@ -58,11 +58,11 @@ class CSVTimeseriesReader(pyaro.timeseries.AutoFilterReaderEngine.AutoFilterRead
     ):
         """open a new csv timeseries-reader
 
-        :param filename_or_obj_or_url: path-like object to csv-file. For multi-file support
+        :param filename: path-like object to csv-file. For multi-file support
             path may also start with the `glob:`-keyword, e.g. `glob:/data/csvdir/**/*.csv` will
             add all csv-files under `/data/csvdir/`, recursively.
             All multi-files need to have the same csv-format.
-            If filename_or_obj_or_url is a directory, all *.csv file in this directory will be read,
+            If filename is a directory, all *.csv file in this directory will be read,
             i.e. it is mapped to glob:/directory/*.csv
         :param columns: mapping of column in the csv-file to key, see col_keys().
             Column-numbering starts with 0.

--- a/src/pyaro/timeseries/AutoFilterReaderEngine.py
+++ b/src/pyaro/timeseries/AutoFilterReaderEngine.py
@@ -122,7 +122,7 @@ class AutoFilterEngine(Engine):
     def args(self):
         sig = inspect.signature(self.reader_class().__init__)
         pars = tuple(sig.parameters.keys())
-        return pars[1:]
+        return pars[:]
 
-    def open(self, filename, *args, **kwargs) -> Reader:
-        return self.reader_class()(filename, *args, **kwargs)
+    def open(self, *args, **kwargs) -> Reader:
+        return self.reader_class()(*args, **kwargs)

--- a/src/pyaro/timeseries/Engine.py
+++ b/src/pyaro/timeseries/Engine.py
@@ -5,7 +5,7 @@ class Engine(abc.ABC):
     """The engine is the 'singleton' generator object for databases of the engines type."""
 
     @abc.abstractmethod
-    def open(self, filename_or_obj_or_url, *, filters=None):
+    def open(self, *, filters=None):
         """open-function of the timeseries, initializing the reader-object, i.e.
         equivalent to Reader(filename_or_object_or_url, *, filters)
 
@@ -17,10 +17,9 @@ class Engine(abc.ABC):
     @property
     @abc.abstractmethod
     def args(self) -> list[str]:
-        """return a tuple of parameters to be passed to open_timeseries, including
-        the mandatory filename_or_obj_or_url parameter.
+        """return a tuple of parameters to be passed to open_timeseries
         """
-        return ["filename_or_obj_or_url"]
+        return []
 
     @property
     @abc.abstractmethod

--- a/src/pyaro/timeseries/Reader.py
+++ b/src/pyaro/timeseries/Reader.py
@@ -8,13 +8,12 @@ class Reader(abc.ABC):
     """Baseclass for timeseries. This can be used with a context manager"""
 
     @abc.abstractmethod
-    def __init__(self, filename_or_obj_or_url, *, filters=None):
+    def __init__(self, *, filters=None):
         """Initialize the reader.
 
         This function is usually called from the Engine's open function.
         All parameters should also be listed in the Engine's args function.
 
-        :param filename_or_obj_or_url: location of database instance
         :param filters: list of filters, or dict of (name, kwargs) for FilterFactory
         """
         pass


### PR DESCRIPTION
This is to make nesting of pyaro configurations easier. This is a breaking change and will affect `pyaro-readers` and `pyaerocom`