### PR TITLE
Failing multiuse of valleyfloor_filter

### DIFF
--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1373,14 +1373,12 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
         # Sorting stations by latitude minimizes reloading of data if each topo file
         # is a band that includes 360deg of longitude. This is the case for the merged
         # dataset.
-        topo = None
+        self._topo_file = None
         for k, v in sorted(stations.items(), key=lambda x: x[1].latitude):
             lat = v.latitude
             lon = v.longitude
             alt = v.altitude
-            if self._update_topo_file_path(lat, lon) or topo is None:
-                if topo is not None:
-                    topo.close()
+            if self._update_topo_file_path(lat, lon):
                 topo = xr.load_dataset(self._topo_file)
 
             ralt = self._calculate_relative_altitude(

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1379,6 +1379,8 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
             lon = v.longitude
             alt = v.altitude
             if self._update_topo_file_path(lat, lon) or topo is None:
+                if topo is not None:
+                    topo.close()
                 topo = xr.open_dataset(self._topo_file)
 
             ralt = self._calculate_relative_altitude(

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1381,7 +1381,7 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
             if self._update_topo_file_path(lat, lon) or topo is None:
                 if topo is not None:
                     topo.close()
-                topo = xr.open_dataset(self._topo_file)
+                topo = xr.load_dataset(self._topo_file)
 
             ralt = self._calculate_relative_altitude(
                 lat, lon, radius=self._radius, altitude=alt, topo=topo

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -1373,13 +1373,13 @@ class ValleyFloorRelativeAltitudeFilter(StationFilter):
         # Sorting stations by latitude minimizes reloading of data if each topo file
         # is a band that includes 360deg of longitude. This is the case for the merged
         # dataset.
+        topo = None
         for k, v in sorted(stations.items(), key=lambda x: x[1].latitude):
             lat = v.latitude
             lon = v.longitude
             alt = v.altitude
-            if self._update_topo_file_path(lat, lon):
-                with xr.open_dataset(self._topo_file) as top:
-                    topo = top
+            if self._update_topo_file_path(lat, lon) or topo is None:
+                topo = xr.open_dataset(self._topo_file)
 
             ralt = self._calculate_relative_altitude(
                 lat, lon, radius=self._radius, altitude=alt, topo=topo

--- a/tests/test_CSVTimeSeriesReader.py
+++ b/tests/test_CSVTimeSeriesReader.py
@@ -744,6 +744,54 @@ class TestCSVTimeSeriesReader(unittest.TestCase):
         ) as ts1:
             self.assertTrue(np.all(ts0.data("NOx").values == ts1.data("NOx").values))
 
+    def test_valley_floor_filter_multi_use(self):
+        engines = pyaro.list_timeseries_engines()
+        filter = pyaro.timeseries.filters.get(
+                    "valleyfloor_relaltitude",
+                    topo="tests/testdata/datadir_elevation/gtopo30_subset.nc",
+                    radius=5000,
+                    lower=150,
+                    upper=250,
+                )
+        with engines["csv_timeseries"].open(
+            filename=self.elevation_file,
+            filters=[filter],
+            columns={
+                "variable": 0,
+                "station": 1,
+                "longitude": 2,
+                "latitude": 3,
+                "value": 4,
+                "units": 5,
+                "start_time": 6,
+                "end_time": 7,
+                "altitude": 9,
+                "country": "NO",
+                "standard_deviation": "NaN",
+                "flag": "0",
+            },
+        ) as ts:
+            self.assertEqual(len(ts.stations()), 3)
+
+        with engines["csv_timeseries"].open(
+            filename=self.elevation_file,
+            filters=[filter],
+            columns={
+                "variable": 0,
+                "station": 1,
+                "longitude": 2,
+                "latitude": 3,
+                "value": 4,
+                "units": 5,
+                "start_time": 6,
+                "end_time": 7,
+                "altitude": 9,
+                "country": "NO",
+                "standard_deviation": "NaN",
+                "flag": "0",
+            },
+        ) as ts:
+            self.assertEqual(len(ts.stations()), 3)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When the valleyfloor_filter is used multiple times `topo` might not be set. This PR adds another conditional that `topo` must be read if not set