### PR TITLE
Remove friend method on Data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyaro
-version = 0.1.4.dev0
+version = 0.2.0.dev0
 author = Heiko Klein, Daniel Heinesen
 author_email = Heiko.Klein@met.no
 description = pyaro py-aerocom reader objects

--- a/src/pyaro/timeseries/Data.py
+++ b/src/pyaro/timeseries/Data.py
@@ -21,14 +21,6 @@ class Data(abc.ABC):
     This is the minimum set of columns required for a reader to return.
     A reader is welcome to return a self-implemented subclass of
     Data.
-
-    All Data arrays are accessible as a dict or as property, e.g.
-    ```
-    td = Data()
-    print(td.values)
-    print(td["values"])
-    ```
-
     """
 
     @abc.abstractmethod

--- a/src/pyaro/timeseries/Data.py
+++ b/src/pyaro/timeseries/Data.py
@@ -31,37 +31,11 @@ class Data(abc.ABC):
 
     """
 
-    _dtype = [
-        ("values", "f"),
-        ("stations", "U64"),
-        ("latitudes", "f"),
-        ("longitudes", "f"),
-        ("altitudes", "f"),
-        ("start_times", "datetime64[s]"),
-        ("end_times", "datetime64[s]"),
-        ("flags", "i2"),
-        ("standard_deviations", "f"),
-    ]
-
-    def __init__(self, variable, units) -> None:
-        self._variable = variable
-        self._units = units
-
-    def _set_variable(self, variable: str) -> None:
-        """Friend method to set the variable name
-
-        This is the setter function for variable. It should only be called by
-        friend-classes like VariableNameChanger.
-
-        :param variable: variable-name
-        """
-        self._variable = variable
-
     @abc.abstractmethod
     def keys(self):
         """all available data-fields, excluding variable and units which are
         considered metadata"""
-        return {}.keys()
+        raise NotImplementedError
 
     @abc.abstractmethod
     def slice(self, index):  # -> Self: for 3.11
@@ -70,30 +44,32 @@ class Data(abc.ABC):
         :param index: A boolean index of the size of data or integer. array
         :return: a new Data object
         """
-        pass
+        raise NotImplementedError
 
     def __getitem__(self, key):
         return self.slice(key)
 
     @abc.abstractmethod
     def __len__(self) -> int:
-        pass
+        raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def variable(self) -> str:
         """Variable name for all the data
 
         :return: variable name
         """
-        return self._variable
+        raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def units(self) -> str:
         """Units in CF-notation, the same unit applies to all values
 
         :return: Units in CF-notation
         """
-        return self._units
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -102,7 +78,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of floats
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -111,7 +87,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of strings, max-length 64-chars
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -120,7 +96,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of floats
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -129,7 +105,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of floats
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -138,7 +114,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of floats
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -148,7 +124,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of datetime64
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -158,7 +134,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of datetime64
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -167,7 +143,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of ints
         """
-        return
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -177,7 +153,7 @@ class Data(abc.ABC):
 
         :return: 1dim array of floats
         """
-        return
+        raise NotImplementedError
 
 
 class DynamicRecArrayException(Exception):
@@ -259,7 +235,7 @@ class NpStructuredData(Data):
         ("standard_deviations", "f"),
     ]
 
-    def __init__(self, variable="", units="") -> None:
+    def __init__(self, variable: str = "", units: str = "") -> None:
         self._variable = variable
         self._units = units
         self._data = DynamicRecArray(self._dtype)

--- a/src/pyaro/timeseries/Filter.py
+++ b/src/pyaro/timeseries/Filter.py
@@ -282,8 +282,11 @@ class VariableNameFilter(Filter):
 
     def filter_data(self, data, stations, variables) -> Data:
         """Translate data's variable"""
-        data._set_variable(self._reader_to_new.get(data.variable, data.variable))
-        return data
+        from .Wrappers import VariableNameChangingReaderData
+
+        return VariableNameChangingReaderData(
+            data, self._reader_to_new.get(data.variable, data.variable)
+        )
 
     def filter_variables(self, variables: list[str]) -> list[str]:
         """change variable name and reduce variables applying include and exclude parameters

--- a/src/pyaro/timeseries/Wrappers.py
+++ b/src/pyaro/timeseries/Wrappers.py
@@ -2,6 +2,65 @@ from .Reader import Reader
 from .Data import Data
 
 
+class VariableNameChangingReaderData(Data):
+    def __init__(self, data: Data, varname: str):
+        self._data = data
+        self._variable = varname
+
+    def keys(self):
+        return self._data.keys()
+
+    def slice(self, index):
+        return VariableNameChangingReaderData(self._data.slice(index), self._variable)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    @property
+    def variable(self) -> str:
+        return self._variable
+
+    @property
+    def units(self) -> str:
+        return self._data.units
+
+    @property
+    def values(self):
+        return self._data.values
+
+    @property
+    def stations(self):
+        return self._data.stations
+
+    @property
+    def latitudes(self):
+        return self._data.latitudes
+
+    @property
+    def longitudes(self):
+        return self._data.altitudes
+
+    @property
+    def altitudes(self):
+        return self._data.altitudes
+
+    @property
+    def start_times(self):
+        return self._data.start_times
+
+    @property
+    def end_times(self):
+        return self._data.end_times
+
+    @property
+    def flags(self):
+        return self._data.flags
+
+    @property
+    def standard_deviations(self):
+        return self._data.standard_deviations
+
+
 class VariableNameChangingReader(Reader):
     """A pyaro.timeseries.Reader wrapper taking a real Reader implementation and
     changing variable names in the original reader. Example:
@@ -35,15 +94,14 @@ class VariableNameChangingReader(Reader):
         """
         return self._reader
 
-    def data(self, varname):
+    def data(self, varname) -> Data:
         """Get the data from the reader with one of the new variable names.
 
         :param varname: new variable name
         :return: data with new variable name
         """
         data = self.reader.data(self._new_to_reader.get(varname, varname))
-        data._set_variable(varname)
-        return data
+        return VariableNameChangingReaderData(data, varname)
 
     def stations(self):
         return self._reader.stations()


### PR DESCRIPTION
This makes `Data` a bit cleaner and it is a bit more obvious which methods should be implemented

I am curious if dict-like access on `Data` is necessary. It has not been implemented for the readers and those seem to work. The `__getitem__` element is also implemented as a call to `slice`, which is wrong if we want dict-like access